### PR TITLE
Use cha gem instead of chatwork gem

### DIFF
--- a/capistrano-around_chatwork.gemspec
+++ b/capistrano-around_chatwork.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", ">= 3.0.0"
-  spec.add_dependency "chatwork", ">= 0.4.0"
+  spec.add_dependency "cha", ">= 1.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/capistrano/around_chatwork.rb
+++ b/lib/capistrano/around_chatwork.rb
@@ -1,5 +1,5 @@
 require "capistrano/around_chatwork/version"
-require "chatwork"
+require "cha"
 
 module Capistrano
   module AroundChatwork
@@ -8,8 +8,8 @@ module Capistrano
     end
 
     def self.post_chatwork(message)
-      ChatWork.api_key = fetch(:chatwork_api_token)
-      ChatWork::Message.create(room_id: fetch(:chatwork_room_id), body: message)
+      client = Cha.new(api_token: fetch(:chatwork_api_token))
+      client.create_room_message(fetch(:chatwork_room_id), message)
     end
   end
 end


### PR DESCRIPTION
When use `capistrano-around_chatwork` and [capistrano-chatwork](https://github.com/mitukiii/capistrano-chatwork), dependency is conflict

Gemfile

```ruby
group :development do
  gem "capistrano-around_chatwork", require: false
  gem "capistrano-chatwork", require: false, github: "sue445/capistrano-chatwork", branch: "relax_cha_dependency"
  gem "cha", ">= 1.2.0"
end
```

```sh
Bundler could not find compatible versions for gem "faraday":
  In Gemfile:
    cha (>= 1.2.0) was resolved to 1.2.0, which depends on
      faraday (~> 0.11.0)

    capistrano-around_chatwork was resolved to 0.1.1, which depends on
      chatwork (>= 0.4.0) was resolved to 0.4.0, which depends on
        faraday (~> 0.9.0)
```